### PR TITLE
Add snapcraft.yaml for snap package

### DIFF
--- a/snap/local/gnome-shell-extension-installer.wrapper
+++ b/snap/local/gnome-shell-extension-installer.wrapper
@@ -1,0 +1,5 @@
+#!/bin/sh
+export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
+export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
+
+exec "${SNAP}/gnome-shell-extension-installer" "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,31 @@
+name: gnome-shell-extension-installer
+base: core20
+version: '1.7'
+summary: GNOME Shell Extension Installer
+description: |
+  A bash script to install and search extensions from [extensions.gnome.org](https://extensions.gnome.org/).
+
+grade: stable
+confinement: classic
+
+apps:
+  gnome-shell-extension-installer:
+    command: gnome-shell-extension-installer.wrapper
+    plugs: [home]
+
+parts:
+  gnome-shell-extension-installer:
+    plugin: dump
+    organize:
+      snap/local/gnome-shell-extension-installer.wrapper: gnome-shell-extension-installer.wrapper
+    source: .
+
+  utils:
+    plugin: nil
+    stage-packages:
+      - bash
+      - curl
+      - dbus
+      - perl
+      - git
+      - less


### PR DESCRIPTION
You can build a snap package by using snapcraft, or create a project on https://snapcraft.io/ to build by the cloud and publish on the Snap Store. That will make the package available for the user using snap package on several Linux distro.