### PR TITLE
Fix GNOME 40+ version check

### DIFF
--- a/gnome-shell-extension-installer
+++ b/gnome-shell-extension-installer
@@ -454,6 +454,9 @@ done
 
 GNOME_VERSION=$( gnome-shell --version 2> /dev/null |
                  sed -n "s/^.* \([0-9]\+\.[0-9]\+\).*$/\1/p" )
+if [[ "${GNOME_VERSION%%"."*}" -ge 40 ]]; then
+  GNOME_VERSION="${GNOME_VERSION%%"."*}"
+fi
 DOWNLOAD_PARAMETERS="-Lfs"
 EXTENSIONS_SITE="https://extensions.gnome.org"
 SORT="popularity"


### PR DESCRIPTION
So, for GNOME 40+, the only part of the version which matters is the 40. On Ubuntu 21.10, this script fails because it tries to find extensions for GNOME 40.5, while it should try to find for GNOME 40.

This is tested and it's working fine.